### PR TITLE
Allow MessageFormat content in function parameters + replace `strictNumberSign` option with broader `strict`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,19 +13,28 @@ the following possible keys:
   `'zero', 'one', 'two', 'few', 'many', 'other'`. To disable this check, pass in
   an empty array.
 
-- `strictNumberSign` – Inside a `plural` or `selectordinal` statement, a pound
-  symbol (`#`) is replaced with the input number. By default, `#` is also parsed
-  as a special character in nested statements too, and can be escaped using
-  apostrophes (`'#'`). Setting `strictNumberSign` to true will make the parser
-  follow the ICU MessageFormat spec more closely, and only parse `#` as a
-  special character directly inside a `plural` or `selectordinal` statement.
-  Outside those, `#` and `'#'` will be parsed as literal text.
+- `strict` – By default, the parsing applies a few relaxations to the ICU
+  MessageFormat spec. Setting `strict: true` will disable these relaxations:
+  - The `argType` of `simpleArg` formatting functions will be restricted to the
+    set of `number`, `date`, `time`, `spellout`, `ordinal`, and `duration`,
+    rather than accepting any lower-case identifier that does not start with a
+    number.
+  - The optional `argStyle` of `simpleArg` formatting functions will not be
+    parsed as any other text, but instead as the spec requires: "In
+    argStyleText, every single ASCII apostrophe begins and ends quoted literal
+    text, and unquoted {curly braces} must occur in matched pairs."
+  - Inside a `plural` or `selectordinal` statement, a pound symbol (`#`) is
+    replaced with the input number. By default, `#` is also parsed as a special
+    character in nested statements too, and can be escaped using apostrophes
+    (`'#'`). In strict mode `#` will be parsed as a special character only
+    directly inside a `plural` or `selectordinal` statement. Outside those, `#`
+    and `'#'` will be parsed as literal text.
 
-The parser only supports the default `DOUBLE_OPTIONAL` [apostrophe mode]. A
-single apostrophe only starts quoted literal text if preceded by a curly brace
-(`{}`) or a pound symbol (`#`) inside a `plural` or `selectordinal` statement,
-depending on the value of `strictNumberSign`. Otherwise, it is a literal
-apostrophe. A double apostrophe is always a literal apostrophe.
+The parser only supports the default `DOUBLE_OPTIONAL` [apostrophe mode], in
+which a single apostrophe only starts quoted literal text if it immediately
+precedes a curly brace `{}`, or a pound symbol `#` if inside a plural format. A
+literal apostrophe `'` is represented by either a single `'` or a doubled `''`
+apostrophe character.
 
 [ICU MessageFormat]: https://messageformat.github.io/guide/
 [messageformat]: https://messageformat.github.io/
@@ -130,7 +139,9 @@ type Function = {
   type: 'function',
   arg: Identifier,
   key: Identifier,
-  param: string | null
+  param: {
+    tokens: options.strict ? [string] : (Token | Octothorpe)[]
+  } | null
 }
 
 type PluralCase = {
@@ -140,7 +151,7 @@ type PluralCase = {
 
 type SelectCase = {
   key: Identifier,
-  tokens: strictNumberSign ? Token[] : (Token | Octothorpe)[]
+  tokens: options.strict ? Token[] : (Token | Octothorpe)[]
 }
 
 type Octothorpe = {

--- a/parser.pegjs
+++ b/parser.pegjs
@@ -42,7 +42,7 @@ plural = '{' _ arg:id _ ',' _ type:(m:('plural'/'selectordinal') { inPlural = tr
     };
   }
 
-function = '{' _ arg:id _ ',' _ key:(m:id { if (options.strictNumberSign) { inPlural = false; } return m; }) _ param:functionParam? '}' {
+function = '{' _ arg:id _ ',' _ key:functionKey _ param:functionParam? '}' {
     return {
       type: 'function',
       arg: arg,
@@ -65,6 +65,15 @@ offset = _ 'offset' _ ':' _ d:digits _ { return d; }
 pluralKey
   = id
   / '=' d:digits { return d; }
+
+functionKey =
+  ! 'select'
+  ! 'plural'
+  ! 'selectordinal'
+  key:id & { return key.toLowerCase() === key && !/^\d/.test(key) } {
+    if (options.strictNumberSign) { inPlural = false; }
+    return key;
+  }
 
 functionParam = _ ',' str:paramChars+ { return str.join(''); }
 

--- a/parser.pegjs
+++ b/parser.pegjs
@@ -66,14 +66,11 @@ pluralKey
   = id
   / '=' d:digits { return d; }
 
-functionKey =
-  ! 'select'
-  ! 'plural'
-  ! 'selectordinal'
-  key:id & { return key.toLowerCase() === key && !/^\d/.test(key) } {
-    if (options.strict) { inPlural = false; }
-    return key;
-  }
+functionKey
+  = 'number' / 'date' / 'time' / 'spellout' / 'ordinal' / 'duration'
+  / ! 'select' ! 'plural' ! 'selectordinal' key:id
+    & { return !options.strict && key.toLowerCase() === key && !/^\d/.test(key) }
+    { return key }
 
 functionParam
   = _ ',' tokens:token* & { return !options.strict } { return { tokens: tokens } }

--- a/parser.pegjs
+++ b/parser.pegjs
@@ -75,7 +75,15 @@ functionKey =
     return key;
   }
 
-functionParam = _ ',' tokens:token* { return { tokens: tokens }; }
+functionParam
+  = _ ',' tokens:token* & { return !options.strictFunctionParam } { return { tokens: tokens } }
+  / _ ',' parts:strictFunctionParamPart* { return { tokens: [parts.join('')] } }
+
+strictFunctionParamPart
+  = p:[^'{}]+ { return p.join('') }
+  / doubleapos
+  / "'" quoted:inapos "'" { return quoted }
+  / '{' p:strictFunctionParamPart* '}' { return '{' + p.join('') + '}' }
 
 doubleapos = "''" { return "'"; }
 

--- a/parser.pegjs
+++ b/parser.pegjs
@@ -16,7 +16,7 @@ argument = '{' _ arg:id _ '}' {
     };
   }
 
-select = '{' _ arg:id _ ',' _ (m:'select' { if (options.strictNumberSign) { inPlural = false; } return m; }) _ ',' _ cases:selectCase+ _ '}' {
+select = '{' _ arg:id _ ',' _ (m:'select' { if (options.strict) { inPlural = false; } return m; }) _ ',' _ cases:selectCase+ _ '}' {
     return {
       type: 'select',
       arg: arg,
@@ -71,12 +71,12 @@ functionKey =
   ! 'plural'
   ! 'selectordinal'
   key:id & { return key.toLowerCase() === key && !/^\d/.test(key) } {
-    if (options.strictNumberSign) { inPlural = false; }
+    if (options.strict) { inPlural = false; }
     return key;
   }
 
 functionParam
-  = _ ',' tokens:token* & { return !options.strictFunctionParam } { return { tokens: tokens } }
+  = _ ',' tokens:token* & { return !options.strict } { return { tokens: tokens } }
   / _ ',' parts:strictFunctionParamPart* { return { tokens: [parts.join('')] } }
 
 strictFunctionParamPart

--- a/parser.pegjs
+++ b/parser.pegjs
@@ -75,12 +75,7 @@ functionKey =
     return key;
   }
 
-functionParam = _ ',' str:paramChars+ { return str.join(''); }
-
-paramChars
-  = doubleapos
-  / quotedCurly
-  / [^}]
+functionParam = _ ',' tokens:token* { return { tokens: tokens }; }
 
 doubleapos = "''" { return "'"; }
 

--- a/test.js
+++ b/test.js
@@ -247,17 +247,17 @@ describe("Plurals", function() {
     ]);
   })
 
-  describe('options.strictNumberSign', function() {
+  describe('options.strict', function() {
     var src = "{NUM, plural, one{# {VAR,select,key{# '#' one#}}} two{two}}";
 
-    it('should parse # correctly without strictNumberSign', function() {
+    it('should parse # correctly without strict option', function() {
       expect(parse(src)[0].cases[0].tokens[2].cases[0].tokens).to.eql([
         { type: 'octothorpe' }, ' # one', { type: 'octothorpe' }
       ]);
     })
 
-    it('should parse # correctly with strictNumberSign', function() {
-      expect(parse(src, { strictNumberSign: true })[0].cases[0].tokens[2].cases[0].tokens).to.eql([
+    it('should parse # correctly with strict option', function() {
+      expect(parse(src, { strict: true })[0].cases[0].tokens[2].cases[0].tokens).to.eql([
         "# '#' one#"
       ]);
     })
@@ -362,9 +362,9 @@ describe("Functions", function() {
     })
   })
 
-  describe('options.strictFunctionParam', function() {
-    it('should obey strictFunctionParam if set', function() {
-      expect(parse("{foo, date, {bar'}', quote'', other{#}}}", { strictFunctionParam: true })[0]).to.eql({
+  describe('options.strict', function() {
+    it('should obey strict option', function() {
+      expect(parse("{foo, date, {bar'}', quote'', other{#}}}", { strict: true })[0]).to.eql({
         type: 'function',
         arg: 'foo',
         key: 'date',
@@ -372,9 +372,9 @@ describe("Functions", function() {
       })
     })
 
-    it('should require matched braces in param if strictFunctionParam is set', function() {
+    it('should require matched braces in param if strict option is set', function() {
       expect(function() {
-        parse("{foo, date, {bar{}}", { strictFunctionParam: true })
+        parse("{foo, date, {bar{}}", { strict: true })
       }).to.throwError();
     })
   })

--- a/test.js
+++ b/test.js
@@ -318,6 +318,42 @@ describe("Functions", function() {
     expect(parse("{var,date,y-M-d, HH:mm:ss zzzz}")[0].param.tokens).to.eql(["y-M-d, HH:mm:ss zzzz"]);
   })
 
+  it('should accept parameters containing a basic variable', function() {
+    expect(parse('{foo, date, {bar}}')[0]).to.eql({
+      type: 'function',
+      arg: 'foo',
+      key: 'date',
+      param: { tokens: [' ', { arg: 'bar', type: 'argument' }] }
+    })
+  })
+
+  it('should accept parameters containing a select', function() {
+    expect(parse('{foo, date, {bar, select, other{baz}}}')[0]).to.eql({
+      type: 'function',
+      arg: 'foo',
+      key: 'date',
+      param: { tokens: [' ', {
+        arg: 'bar',
+        type: 'select',
+        cases: [{ key: 'other', tokens: ['baz'] }]
+      }] }
+    })
+  })
+
+  it('should accept parameters containing a plural', function() {
+    expect(parse('{foo, date, {bar, plural, other{#}}}')[0]).to.eql({
+      type: 'function',
+      arg: 'foo',
+      key: 'date',
+      param: { tokens: [' ', {
+        arg: 'bar',
+        type: 'plural',
+        offset: 0,
+        cases: [{ key: 'other', tokens: [{ type: 'octothorpe' }] }]
+      }] }
+    })
+  })
+
   it("should be gracious with whitespace around arg and key", function() {
     var firstRes = JSON.stringify(parse('{var, date}'));
     expect(JSON.stringify(parse('{ var, date }'))).to.eql(firstRes);
@@ -325,6 +361,7 @@ describe("Functions", function() {
     expect(JSON.stringify(parse('{\nvar,   \ndate\n}'))).to.eql(firstRes);
   });
 });
+
 describe("Nested/Recursive blocks", function() {
 
   it("should allow a select statement inside of a select statement", function() {

--- a/test.js
+++ b/test.js
@@ -363,7 +363,13 @@ describe("Functions", function() {
   })
 
   describe('options.strict', function() {
-    it('should obey strict option', function() {
+    it('should require known function key with strict option', function() {
+      expect(function() { parse('{foo, bar}') }).to.not.throwError()
+      expect(function() { parse('{foo, bar}', { strict: true }) }).to.throwError()
+      expect(function() { parse('{foo, date}', { strict: true }) }).to.not.throwError()
+    })
+
+    it('parameter parsing should obey strict option', function() {
       expect(parse("{foo, date, {bar'}', quote'', other{#}}}", { strict: true })[0]).to.eql({
         type: 'function',
         arg: 'foo',
@@ -372,7 +378,7 @@ describe("Functions", function() {
       })
     })
 
-    it('should require matched braces in param if strict option is set', function() {
+    it('should require matched braces in parameter if strict option is set', function() {
       expect(function() {
         parse("{foo, date, {bar{}}", { strict: true })
       }).to.throwError();

--- a/test.js
+++ b/test.js
@@ -230,27 +230,31 @@ describe("Plurals", function() {
   });
 
   it("should support quoting", function() {
-    expect(parse("{NUM, plural, one{{x,date,y-M-dd # '#'}} two{two}}")[0].cases[0].tokens[0].type).to.eql('function');
-    expect(parse("{NUM, plural, one{{x,date,y-M-dd # '#'}} two{two}}")[0].cases[0].tokens[0].arg).to.eql('x');
-    expect(parse("{NUM, plural, one{{x,date,y-M-dd # '#'}} two{two}}")[0].cases[0].tokens[0].key).to.eql('date');
-    // Octothorpe is not special here regardless of strict number sign
-    expect(parse("{NUM, plural, one{{x,date,y-M-dd # '#'}} two{two}}")[0].cases[0].tokens[0].param).to.eql("y-M-dd # '#'");
+    expect(parse("{NUM, plural, one{{x,date,y-M-dd # '#'}} two{two}}")[0].cases[0].tokens).to.eql([{
+      type: 'function', arg: 'x', key: 'date',
+      param: {
+        tokens: [ 'y-M-dd ', { type: 'octothorpe' }, ' #' ]
+      }
+    }]);
+    expect(parse("{NUM, plural, one{# '' #} two{two}}")[0].cases[0].tokens).to.eql([
+      { type: 'octothorpe' }, " ' ", { type: 'octothorpe' }
+    ]);
+    expect(parse("{NUM, plural, one{# '#'} two{two}}")[0].cases[0].tokens).to.eql([
+      { type: 'octothorpe' }, ' #'
+    ]);
+    expect(parse("{NUM, plural, one{one#} two{two}}")[0].cases[0].tokens).to.eql([
+      'one', { type: 'octothorpe' }
+    ]);
 
-    expect(parse("{NUM, plural, one{# '' #} two{two}}")[0].cases[0].tokens[0].type).to.eql('octothorpe');
-    expect(parse("{NUM, plural, one{# '' #} two{two}}")[0].cases[0].tokens[1]).to.eql(" ' ");
-    expect(parse("{NUM, plural, one{# '' #} two{two}}")[0].cases[0].tokens[2].type).to.eql('octothorpe');
-    expect(parse("{NUM, plural, one{# '#'} two{two}}")[0].cases[0].tokens[0].type).to.eql('octothorpe');
-    expect(parse("{NUM, plural, one{# '#'} two{two}}")[0].cases[0].tokens[1]).to.eql(" #");
-
-    expect(parse("{NUM, plural, one{one#} two{two}}")[0].cases[0].tokens[0]).to.eql('one');
-    expect(parse("{NUM, plural, one{one#} two{two}}")[0].cases[0].tokens[1].type).to.eql('octothorpe');
-
+    var src = "{NUM, plural, one{# {VAR,select,key{# '#' one#}}} two{two}}";
     // without strict number sign
-    expect(parse("{NUM, plural, one{# {VAR,select,key{# '#' one#}}} two{two}}")[0].cases[0].tokens[2].cases[0].tokens[0].type).to.eql('octothorpe')
-    expect(parse("{NUM, plural, one{# {VAR,select,key{# '#' one#}}} two{two}}")[0].cases[0].tokens[2].cases[0].tokens[1]).to.eql(' # one')
-    expect(parse("{NUM, plural, one{# {VAR,select,key{# '#' one#}}} two{two}}")[0].cases[0].tokens[2].cases[0].tokens[2].type).to.eql('octothorpe')
+    expect(parse(src)[0].cases[0].tokens[2].cases[0].tokens).to.eql([
+      { type: 'octothorpe' }, ' # one', { type: 'octothorpe' }
+    ]);
     // with strict number sign
-    expect(parse("{NUM, plural, one{# {VAR,select,key{# '#' one#}}} two{two}}", { strictNumberSign: true })[0].cases[0].tokens[2].cases[0].tokens[0]).to.eql('# \'#\' one#')
+    expect(parse(src, { strictNumberSign: true })[0].cases[0].tokens[2].cases[0].tokens).to.eql([
+      "# '#' one#"
+    ]);
   });
 
 });
@@ -285,33 +289,33 @@ describe("Functions", function() {
   })
 
   it("should accept no parameters", function() {
-    expect(parse('{var,date}')[0].type).to.eql('function');
-    expect(parse('{var,date}')[0].key).to.eql('date');
-    expect(parse('{var,date}')[0].param).to.be.null;
+    expect(parse('{var,date}')[0]).to.eql({
+      type: 'function', arg: 'var', key: 'date', param: null
+    });
   })
 
   it("should accept parameters", function() {
-    expect(parse('{var,date,long}')[0].type).to.eql('function');
-    expect(parse('{var,date,long}')[0].key).to.eql('date');
-    expect(parse('{var,date,long}')[0].param).to.eql('long');
-    expect(parse('{var,date,long,short}')[0].param).to.eql('long,short');
+    expect(parse('{var,date,long}')[0]).to.eql({
+      type: 'function', arg: 'var', key: 'date', param: { tokens: ['long'] }
+    });
+    expect(parse('{var,date,long,short}')[0].param.tokens).to.eql(['long,short']);
   })
 
   it("should accept parameters with whitespace", function() {
-    expect(parse('{var,date,y-M-d HH:mm:ss zzzz}')[0].type).to.eql('function');
-    expect(parse('{var,date,y-M-d HH:mm:ss zzzz}')[0].key).to.eql('date');
-    expect(parse('{var,date,y-M-d HH:mm:ss zzzz}')[0].param).to.eql('y-M-d HH:mm:ss zzzz');
-    expect(parse('{var,date,   y-M-d HH:mm:ss zzzz    }')[0].param).to.eql('   y-M-d HH:mm:ss zzzz    ');
+    expect(parse('{var,date,y-M-d HH:mm:ss zzzz}')[0]).to.eql({
+      type: 'function', arg: 'var', key: 'date', param: { tokens: ['y-M-d HH:mm:ss zzzz'] }
+    });
+    expect(parse('{var,date,   y-M-d HH:mm:ss zzzz    }')[0].param.tokens).to.eql(['   y-M-d HH:mm:ss zzzz    ']);
   })
 
   it("should accept parameters with special characters", function() {
-    expect(parse("{var,date,y-M-d '{,}' '' HH:mm:ss zzzz}")[0].type).to.eql('function');
-    expect(parse("{var,date,y-M-d '{,}' '' HH:mm:ss zzzz}")[0].key).to.eql('date');
-    expect(parse("{var,date,y-M-d '{,}' '' HH:mm:ss zzzz}")[0].param).to.eql("y-M-d {,} ' HH:mm:ss zzzz");
-    expect(parse("{var,date,y-M-d '{,}' '' HH:mm:ss zzzz'}'}")[0].param).to.eql("y-M-d {,} ' HH:mm:ss zzzz}");
-    expect(parse("{var,date,y-M-d # HH:mm:ss zzzz}")[0].param).to.eql("y-M-d # HH:mm:ss zzzz");
-    expect(parse("{var,date,y-M-d '#' HH:mm:ss zzzz}")[0].param).to.eql("y-M-d '#' HH:mm:ss zzzz");
-    expect(parse("{var,date,y-M-d, HH:mm:ss zzzz}")[0].param).to.eql("y-M-d, HH:mm:ss zzzz");
+    expect(parse("{var,date,y-M-d '{,}' '' HH:mm:ss zzzz}")[0]).to.eql({
+      type: 'function', arg: 'var', key: 'date', param: { tokens: [ 'y-M-d {,} \' HH:mm:ss zzzz' ] }
+    });
+    expect(parse("{var,date,y-M-d '{,}' '' HH:mm:ss zzzz'}'}")[0].param.tokens).to.eql(["y-M-d {,} ' HH:mm:ss zzzz}"]);
+    expect(parse("{var,date,y-M-d # HH:mm:ss zzzz}")[0].param.tokens).to.eql(["y-M-d # HH:mm:ss zzzz"]);
+    expect(parse("{var,date,y-M-d '#' HH:mm:ss zzzz}")[0].param.tokens).to.eql(["y-M-d '#' HH:mm:ss zzzz"]);
+    expect(parse("{var,date,y-M-d, HH:mm:ss zzzz}")[0].param.tokens).to.eql(["y-M-d, HH:mm:ss zzzz"]);
   })
 
   it("should be gracious with whitespace around arg and key", function() {

--- a/test.js
+++ b/test.js
@@ -277,6 +277,13 @@ describe("Ordinals", function() {
 
 });
 describe("Functions", function() {
+  it("should require lower-case type", function() {
+    expect(function(){ parse('{var,date}'); }).to.not.throwError();
+    expect(function(){ parse('{var,Date}'); }).to.throwError();
+    expect(function(){ parse('{var,daTe}'); }).to.throwError();
+    expect(function(){ parse('{var,9ate}'); }).to.throwError();
+  })
+
   it("should accept no parameters", function() {
     expect(parse('{var,date}')[0].type).to.eql('function');
     expect(parse('{var,date}')[0].key).to.eql('date');


### PR DESCRIPTION
This is part of a possible solution for messageformat/messageformat#201, and in brief it allows for any formatted content in the optional `argStyleText` of a custom formatter function. To be clear, this is outside the official spec, not supported by other parsers, and it does theoretically break input that is valid according to the spec:
> In argStyleText, every single ASCII apostrophe begins and ends quoted literal text, and unquoted {curly braces} must occur in matched pairs.

This change would not mean that any input that was previously ok with this library would not be ok after the change, as the parameter chars could not previously include an unquoted `}`.

This change would require a major-version update for `messageformat-parser`, but probably not for `messageformat`.